### PR TITLE
Updated to Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_more_shapes"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Leon Suchy"]
 license = "MIT OR Apache-2.0"
@@ -13,13 +13,13 @@ exclude = ["/assets/screenshots/**"]
 
 [dependencies]
 # The parts of bevy relevant to meshes and shapes as well as math
-bevy = { version = "0.10", features = ["bevy_render"] }
+bevy = { version = "0.11", features = ["bevy_render"] }
 # This crate is used to triangulate polygons.
 triangulate = "0.2.0"
 
 [dev-dependencies]
 # For the showcase we need the full capabilities of the engine.
-bevy = "0.10"
+bevy = "0.11"
 # First person camera controller
-smooth-bevy-cameras = "0.8"
-bevy_normal_material = "0.2.1"
+smooth-bevy-cameras = "0.9"
+bevy_normal_material = { git = "https://github.com/mattatz/bevy_normal_material.git", rev = "e64317399a3659282c43ca3e7dca857ed75e0057" }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Below is a chart which versions of this crate are compatible with which bevy ver
 | 0.3.x   | 0.9.x        |
 | 0.4.x   | 0.10.x       |
 | 0.5.x   | 0.10.x       |
+| 0.6.x   | 0.11.x       |
 
 ## Known Issues
 

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -658,15 +658,12 @@ fn main() {
                 ..default()
             },
         }))
-        .add_plugin(smooth_bevy_cameras::LookTransformPlugin)
-        .add_plugin(FpsCameraPlugin::default())
-        .add_plugin(WireframePlugin)
-        .add_plugin(MouseLockPlugin)
-        .add_plugin(NormalMaterialPlugin)
-        .add_startup_system(spawn_camera)
-        .add_startup_system(spawn_shapes)
-        .add_startup_system(spawn_info_text)
-        .add_system(toggle_wireframe_system)
-        .add_system(lock_camera)
+        .add_plugins(smooth_bevy_cameras::LookTransformPlugin)
+        .add_plugins(FpsCameraPlugin::default())
+        .add_plugins(WireframePlugin)
+        .add_plugins(MouseLockPlugin)
+        .add_plugins(NormalMaterialPlugin)
+        .add_systems(Startup, (spawn_camera, spawn_shapes,spawn_info_text))
+        .add_systems(Update, (toggle_wireframe_system, lock_camera))
         .run();
 }

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -491,11 +491,8 @@ fn spawn_info_text(mut commands: Commands, asset_server: Res<AssetServer>) {
         style: Style {
             align_self: AlignSelf::FlexEnd,
             position_type: PositionType::Absolute,
-            position: UiRect {
-                top: Val::Px(10.0),
-                left: Val::Px(10.0),
-                ..Default::default()
-            },
+            top: Val::Px(10.0),
+            left: Val::Px(10.0),
             ..Default::default()
         },
         text: Text::from_section(
@@ -638,8 +635,8 @@ impl Plugin for MouseLockPlugin {
         app
             // Add default config
             .insert_resource(MouseLock::default())
-            .add_system(automatic_lock_system)
-            .add_system(update_lock.in_base_set(CoreSet::PostUpdate));
+            .add_systems(Update, automatic_lock_system)
+            .add_systems(PostUpdate, update_lock);
     }
 }
 

--- a/migrations.md
+++ b/migrations.md
@@ -18,3 +18,7 @@ If a version is not in here, there were no breaking changes.
 * Cone segment parameter was renamed
 * Cone UVs were redone to make more sense
 * Cone normals have been fixed to account for the slope
+
+## 0.5 -> 0.6
+
+Should work out of the box with no changes.


### PR DESCRIPTION
Hi there!

Just a quick version bump with a couple minor tweaks to make this compatible with Bevy 0.11.

Seems to work fine (tested by running the gallery example).

Some points for review:
* Check migrations.md, that accurate? My PR shouldn't be bringing in any user-visible changes, but I dunno if master had anything going on since 0.5
* bevy_normal_material refers directly to github; the crates.io version was stuck on 0.2 for an unknown reason
* Double-check that the gallery UI renders correctly? Seems to have been a breaking API change there with the top/left. It *seems* alright, though.